### PR TITLE
Fix/marines walking on the same spot

### DIFF
--- a/Assets/Scripts/Core/Characters/Marine.cs
+++ b/Assets/Scripts/Core/Characters/Marine.cs
@@ -73,6 +73,7 @@ public class Marine : MonoBehaviour
 
     public void MoveTo(Vector3 position)
     {
+        agent.stoppingDistance = .1f;
         agent.isStopped = false;
         agent.SetDestination(position);
     }

--- a/Assets/Scripts/MovementSystem/PlayerInput.cs
+++ b/Assets/Scripts/MovementSystem/PlayerInput.cs
@@ -14,6 +14,8 @@ public class PlayerInput : MonoBehaviour
     private float mouseDownTime;
     private Vector2 startMousePosition;
 
+    public float margin = 1f;
+
     private void Update()
     {
         HandleSelectionInput();
@@ -57,7 +59,6 @@ public class PlayerInput : MonoBehaviour
         }
     }
 
-    public float margin = 1f;
     Vector3 GetRandomPointInCircle(Vector3 center, float radius, List<Vector3> assignedPoints)
     {
         Vector2 randomPoint2D = Random.insideUnitCircle * radius;

--- a/Assets/Scripts/MovementSystem/PlayerInput.cs
+++ b/Assets/Scripts/MovementSystem/PlayerInput.cs
@@ -15,6 +15,13 @@ public class PlayerInput : MonoBehaviour
     private Vector2 startMousePosition;
 
     public float margin = 1f;
+    SelectionManager selectionManager;
+
+    private void Start()
+    {
+        if (selectionManager == null)        
+            selectionManager = SelectionManager.Instance;        
+    }
 
     private void Update()
     {
@@ -24,15 +31,13 @@ public class PlayerInput : MonoBehaviour
 
     private void HandleMovementInputs()
     {
-        if (Input.GetMouseButtonDown(1) && SelectionManager.Instance.SelectedMarines.Count > 0)
+        if (Input.GetMouseButtonDown(1) && selectionManager.SelectedMarines.Count > 0)
         {
             if (Physics.Raycast(Camera.ScreenPointToRay(Input.mousePosition), out RaycastHit hit, FloorLayers))
             {
-                List<Marine> selectedMarines = SelectionManager.Instance.SelectedMarines.ToList();
+                List<Marine> selectedMarines = ConvertHashSetMarinesToList();
                 int cantMarines = selectedMarines.Count;
-
-                float totRadius = selectedMarines.Sum(marine => marine.agent.radius + margin) / (2 * Mathf.PI); // calculo del area en la que voy a asignar los posibles puntos para los agentes 
-                Debug.Log("Radio: " + totRadius);
+                float totRadius = CalculateTotalRadius(selectedMarines); // calculo del area en la que voy a asignar los posibles puntos para los agentes 
 
                 List<Vector3> assignedPoints = new List<Vector3>();
 
@@ -42,14 +47,13 @@ public class PlayerInput : MonoBehaviour
                     assignedPoints.Add(randomPoint);
                     selectedMarines[i].MoveTo(randomPoint);
                 }
-
             }
 
             if (Physics.Raycast(Camera.main.ScreenPointToRay(Input.mousePosition), out RaycastHit hitEnemy))
             {
                 if (hitEnemy.transform.GetComponent<Insurgent>())
                 {
-                    foreach (Marine marine in SelectionManager.Instance.SelectedMarines)
+                    foreach (Marine marine in selectionManager.SelectedMarines)
                     {
                         marine.target = hitEnemy.transform.GetComponent<Insurgent>();
                         marine.StartRotating(marine.target.transform);
@@ -77,6 +81,28 @@ public class PlayerInput : MonoBehaviour
         }
 
         return randomPoint;
+    }
+
+    List<Marine> ConvertHashSetMarinesToList()
+    {
+        List<Marine> selectedMarines = new List<Marine>();
+        foreach (Marine marine in  selectionManager.SelectedMarines)
+        {
+            selectedMarines.Add(marine);
+        }
+        return selectedMarines;
+    }
+
+    float CalculateTotalRadius(List<Marine> selectedMarines)
+    {
+        float sum = .0f;
+
+        foreach (var marine in selectedMarines)
+        {
+            sum += marine.agent.radius + margin;
+        }
+
+        return sum / (2 * Mathf.PI);
     }
 
 


### PR DESCRIPTION
## Issue Ticket -fix/marinesWalkingOnTheSameSpot #2

## Problem
Ticket Header: *fix/marinesWalkingOnTheSameSpot*
{ Los agentes tenían todos el mismo destino, por lo que si tenias seleccionado mas de 1 nunca llegaban ya que se amontonan y quedan corriendo en el lugar }

## Solution
{ Al momento de mandar las unidades a algún punto, se calcula en base a la cantidad seleccionada, el área y radio que van a ocupar y a cada una se le da un punto único al que ir dentro de esa área al rededor del punto que las mandas  }